### PR TITLE
refactor(resize): use positional file argument per PRD

### DIFF
--- a/imgpro.py
+++ b/imgpro.py
@@ -716,11 +716,11 @@ def cmd_info(args):
 
 def cmd_resize(args):
     """Handle the resize subcommand."""
-    input_path = Path(args.input)
+    input_path = Path(args.file)
 
     # Validate input file exists
     if not input_path.exists():
-        print(f"Error: File not found: {args.input}", file=sys.stderr)
+        print(f"Error: File not found: {args.file}", file=sys.stderr)
         sys.exit(3)
 
     # Validate it's a JPEG
@@ -1009,8 +1009,7 @@ def main():
     )
 
     resize_parser.add_argument(
-        '--input',
-        required=True,
+        'file',
         help='Path to input image file'
     )
 

--- a/tests/test_cli_direct.py
+++ b/tests/test_cli_direct.py
@@ -282,7 +282,7 @@ class TestCmdResizeDirect:
         output_dir = temp_dir / 'resized'
 
         args = argparse.Namespace(
-            input=str(img_path),
+            file=str(img_path),
             width='300',
             height=None,
             output=str(output_dir),
@@ -305,7 +305,7 @@ class TestCmdResizeDirect:
         output_dir = temp_dir / 'resized'
 
         args = argparse.Namespace(
-            input=str(img_path),
+            file=str(img_path),
             width='300,600,900',
             height=None,
             output=str(output_dir),
@@ -326,7 +326,7 @@ class TestCmdResizeDirect:
         output_dir = temp_dir / 'resized'
 
         args = argparse.Namespace(
-            input=str(img_path),
+            file=str(img_path),
             width=None,
             height='400',
             output=str(output_dir),
@@ -344,7 +344,7 @@ class TestCmdResizeDirect:
         from imgpro import cmd_resize
 
         args = argparse.Namespace(
-            input=str(temp_dir / 'missing.jpg'),
+            file=str(temp_dir / 'missing.jpg'),
             width='300',
             height=None,
             output=str(temp_dir / 'resized'),
@@ -367,7 +367,7 @@ class TestCmdResizeDirect:
         img.save(png_file, 'PNG')
 
         args = argparse.Namespace(
-            input=str(png_file),
+            file=str(png_file),
             width='300',
             height=None,
             output=str(temp_dir / 'resized'),
@@ -387,7 +387,7 @@ class TestCmdResizeDirect:
         img_path = create_test_image_file(1200, 800, directory=temp_dir, filename='test.jpg')
 
         args = argparse.Namespace(
-            input=str(img_path),
+            file=str(img_path),
             width='300',
             height='400',
             output=str(temp_dir / 'resized'),
@@ -407,7 +407,7 @@ class TestCmdResizeDirect:
         img_path = create_test_image_file(1200, 800, directory=temp_dir, filename='test.jpg')
 
         args = argparse.Namespace(
-            input=str(img_path),
+            file=str(img_path),
             width=None,
             height=None,
             output=str(temp_dir / 'resized'),
@@ -427,7 +427,7 @@ class TestCmdResizeDirect:
         img_path = create_test_image_file(1200, 800, directory=temp_dir, filename='test.jpg')
 
         args = argparse.Namespace(
-            input=str(img_path),
+            file=str(img_path),
             width='300',
             height=None,
             output=str(temp_dir / 'resized'),
@@ -447,7 +447,7 @@ class TestCmdResizeDirect:
         img_path = create_test_image_file(1200, 800, directory=temp_dir, filename='test.jpg')
 
         args = argparse.Namespace(
-            input=str(img_path),
+            file=str(img_path),
             width='300',
             height=None,
             output=str(temp_dir / 'resized'),
@@ -468,7 +468,7 @@ class TestCmdResizeDirect:
         output_dir = temp_dir / 'resized'
 
         args = argparse.Namespace(
-            input=str(img_path),
+            file=str(img_path),
             width='400,1200',
             height=None,
             output=str(output_dir),
@@ -490,7 +490,7 @@ class TestCmdResizeDirect:
         output_dir = temp_dir / 'resized'
 
         args = argparse.Namespace(
-            input=str(img_path),
+            file=str(img_path),
             width='800,1200',
             height=None,
             output=str(output_dir),
@@ -515,7 +515,7 @@ class TestCmdResizeDirect:
         output_dir = temp_dir / 'resized'
 
         args = argparse.Namespace(
-            input=str(img_path),
+            file=str(img_path),
             width='300',
             height=None,
             output=str(output_dir),
@@ -627,7 +627,7 @@ class TestMainFunction:
 
         monkeypatch.setattr(sys, 'argv', [
             'imgpro.py', 'resize',
-            '--input', str(img_path),
+            str(img_path),
             '--width', '300',
             '--output', str(output_dir)
         ])
@@ -766,7 +766,7 @@ class TestCmdResizeCorruptImage:
         corrupt_file.write_bytes(b'JFIF fake jpeg header but not a real image')
 
         args = argparse.Namespace(
-            input=str(corrupt_file),
+            file=str(corrupt_file),
             width='300',
             height=None,
             output=str(temp_dir / 'resized'),

--- a/tests/test_resize_cli.py
+++ b/tests/test_resize_cli.py
@@ -12,13 +12,13 @@ def run_imgpro_resize(input_file, *args):
     Run imgpro resize command and return result.
 
     Args:
-        input_file: Path to input image file
+        input_file: Path to input image file (positional argument)
         *args: Additional CLI arguments
 
     Returns:
         tuple: (exit_code, stdout, stderr)
     """
-    cmd = [sys.executable, 'imgpro.py', 'resize', '--input', str(input_file)] + list(args)
+    cmd = [sys.executable, 'imgpro.py', 'resize', str(input_file)] + list(args)
     result = subprocess.run(
         cmd,
         capture_output=True,
@@ -43,8 +43,8 @@ class TestResizeCommandBasics:
         assert result.returncode == 0
         assert 'resize' in result.stdout.lower()
 
-    def test_resize_requires_input_argument(self):
-        """Test that resize command requires --input argument."""
+    def test_resize_requires_file_argument(self):
+        """Test that resize command requires positional file argument."""
         cmd = [sys.executable, 'imgpro.py', 'resize', '--width', '300']
         result = subprocess.run(
             cmd,
@@ -53,7 +53,7 @@ class TestResizeCommandBasics:
             cwd=Path(__file__).parent.parent
         )
         assert result.returncode != 0
-        assert 'required' in result.stderr.lower() or 'required' in result.stdout.lower()
+        assert 'required' in result.stderr.lower() or 'file' in result.stderr.lower()
 
     def test_resize_requires_width_or_height(self):
         """Test that resize requires either --width or --height."""
@@ -62,7 +62,7 @@ class TestResizeCommandBasics:
         # Create test image
         img_path = create_test_image_file(1200, 800, filename='test.jpg')
 
-        cmd = [sys.executable, 'imgpro.py', 'resize', '--input', str(img_path)]
+        cmd = [sys.executable, 'imgpro.py', 'resize', str(img_path)]
         result = subprocess.run(
             cmd,
             capture_output=True,
@@ -313,7 +313,7 @@ class TestResizeOutputHandling:
         try:
             os.chdir(temp_dir)
             cmd = [sys.executable, str(Path(old_cwd) / 'imgpro.py'), 'resize',
-                   '--input', 'test.jpg', '--width', '300']
+                   'test.jpg', '--width', '300']
             result = subprocess.run(cmd, capture_output=True, text=True)
 
             assert result.returncode == 0


### PR DESCRIPTION
## Summary
- Change `imgpro resize` to use positional `<file>` argument instead of `--input` flag
- Aligns with PRD Section 4.2 specification: `imgpro resize <file> [options]`
- Consistent with other commands (info, rename, convert) that use positional arguments

## Breaking Change

**Before:**
```bash
imgpro resize --input photo.jpg --width 300
```

**After:**
```bash
imgpro resize photo.jpg --width 300
```

## Test plan
- [x] Updated tests in `test_resize_cli.py` to use positional argument (TDD red phase - tests failed)
- [x] Updated `imgpro.py` CLI implementation (TDD green phase - tests passed)
- [x] Updated direct unit tests in `test_cli_direct.py`
- [x] Full regression test suite passes (307 passed, 4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)