### PR TITLE
feat: smart output directories (v1.6.0)

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -1,0 +1,72 @@
+# ipro
+
+CLI tool for responsive image processing — resize, convert, rename, and chain operations from the command line.
+
+## Install
+
+```bash
+pipx install ipro-cli
+# or
+pip install ipro-cli
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `ipro info` | Image metadata — dimensions, format, EXIF, aspect ratio |
+| `ipro resize` | Resize by width or height, preserving aspect ratio |
+| `ipro convert` | Convert between JPEG, PNG, WebP, with quality control |
+| `ipro rename` | Fix extensions, add EXIF date prefix |
+| `ipro extract` | Extract frames from MPO, GIF, APNG, WebP, TIFF |
+
+## Quick Examples
+
+```bash
+# Inspect an image
+ipro info photo.jpg
+
+# Resize to 1080px wide
+ipro resize photo.jpg --width 1080
+
+# Convert HEIC to JPEG
+ipro convert photo.heic --format jpeg --quality 85
+
+# Convert to WebP for web optimization
+ipro convert photo.jpg --format webp --quality 80
+
+# Chain commands: convert then resize in one pass
+ipro convert photo.heic --format jpeg --quality 80 + resize --width 1080
+
+# Batch process a directory
+for img in *.jpg; do ipro resize "$img" --width 1500; done
+```
+
+## Format Support
+
+**Read:** JPEG, PNG, HEIC/HEIF, WebP, GIF, TIFF, BMP, DNG, MPO, APNG
+**Write:** JPEG, PNG, WebP
+
+## Features
+
+- Chain commands with `+` — `resize + convert` in a single pass
+- Smart upscaling prevention — skips sizes larger than the original
+- Lanczos resampling for high-quality output
+- Automatic sRGB color profile conversion
+- EXIF stripping by default for web optimization
+- Supports iPhone HEIC photos via pillow-heif
+
+## Requirements
+
+- Python 3.8+
+
+## Links
+
+- [Full documentation](https://github.com/cadentdev/ipro#readme)
+- [Source code](https://github.com/cadentdev/ipro)
+- [Issue tracker](https://github.com/cadentdev/ipro/issues)
+- [Changelog](https://github.com/cadentdev/ipro/blob/main/CHANGELOG.md)
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -46,44 +46,14 @@ A command-line tool for generating multiple resolutions of images to support res
 
 ## Installation
 
-### Prerequisites
-
-- Python 3.8 or higher
-- pip (Python package manager)
-
-### Setup
-
-1. **Clone the repository**:
-
-   ```bash
-   git clone https://github.com/cadentdev/ipro.git
-   cd ipro
-   ```
-
-2. **Create a virtual environment and install dependencies**:
-
-   ```bash
-   python3 -m venv .venv
-   source .venv/bin/activate
-   pip3 install -r requirements.txt
-   ```
-
-3. **Make the script executable** (optional):
-
-   ```bash
-   chmod +x ipro.py
-   ```
-
-### Install with pipx (recommended)
-
-[pipx](https://pipx.pypa.io/) installs `ipro` in an isolated environment and adds it to your PATH:
+### Install from PyPI (recommended)
 
 ```bash
-# Standard install (uses a snapshot of the code)
-pipx install .
+# With pipx (isolated environment, adds to PATH)
+pipx install ipro-cli
 
-# Editable install (reflects changes to ipro.py immediately — useful for development)
-pipx install --editable .
+# Or with pip
+pip install ipro-cli
 ```
 
 Then run from anywhere:
@@ -95,7 +65,23 @@ ipro --help
 To uninstall:
 
 ```bash
-pipx uninstall ipro
+pipx uninstall ipro-cli
+# or: pip uninstall ipro-cli
+```
+
+### Install from source
+
+For development or to get the latest unreleased changes:
+
+```bash
+git clone https://github.com/cadentdev/ipro.git
+cd ipro
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install -r requirements.txt
+
+# Or install with pipx from the local clone
+pipx install .
 ```
 
 ### Troubleshooting Installation

--- a/ipro.py
+++ b/ipro.py
@@ -25,7 +25,7 @@ except ImportError:
     pass  # pillow-heif not installed, HEIF support unavailable
 
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 
 # Exit codes
 EXIT_SUCCESS = 0
@@ -46,8 +46,25 @@ Image.MAX_IMAGE_PIXELS = MAX_IMAGE_PIXELS
 DEFAULT_RESIZE_QUALITY = 90
 DEFAULT_CONVERT_QUALITY = 80
 
-# Output directory
-DEFAULT_OUTPUT_DIR = "output"
+# Known ipro output directory names for chain detection
+IPRO_OUTPUT_DIRS = {'converted', 'renamed', 'extracted', 'output'}
+
+
+def is_ipro_output_dir(dirname):
+    """Check if a directory name is a known ipro output directory."""
+    return dirname in IPRO_OUTPUT_DIRS or dirname.startswith('resized')
+
+
+def get_resize_dir_name(sizes, dimension):
+    """Compute the default output directory name for resize.
+
+    Single size: resized-{size}w or resized-{size}h
+    Multiple sizes: resized
+    """
+    if len(sizes) == 1:
+        suffix = 'w' if dimension == 'width' else 'h'
+        return f"resized-{sizes[0]}{suffix}"
+    return "resized"
 
 # Supported output formats for convert command
 SUPPORTED_OUTPUT_FORMATS = {
@@ -180,18 +197,19 @@ def validate_output_path(output_str, input_path):
     return resolved
 
 
-def resolve_output_dir(args_output, input_path):
+def resolve_output_dir(args_output, input_path, default_dir_name):
     """
-    Resolve the output directory from CLI args and input path.
+    Resolve the output directory from CLI args, input path, and subcommand default.
 
     If args_output is provided, use it (with security validation).
-    If the input is already in an "output" directory (e.g., from chaining),
-    reuse that directory. Otherwise, create an "output" subdirectory next
-    to the source file.
+    If the input is already in an ipro output directory (chaining), go up one
+    level and create default_dir_name as a sibling.
+    Otherwise, create default_dir_name next to the source file.
 
     Args:
         args_output: The --output argument value (str or None)
         input_path: Path object of the input file
+        default_dir_name: Subcommand-specific default dir name (e.g., "converted")
 
     Returns:
         Path object for the output directory
@@ -204,10 +222,11 @@ def resolve_output_dir(args_output, input_path):
             print("Error: Output directory is a symlink — refusing to write", file=sys.stderr)
             sys.exit(EXIT_INVALID_ARGS)
         return output_path
-    elif input_path.parent.name == DEFAULT_OUTPUT_DIR:
-        return input_path.parent
+    elif is_ipro_output_dir(input_path.parent.name):
+        # Chaining: place output as sibling of previous output dir
+        return input_path.parent.parent / default_dir_name
     else:
-        return input_path.parent / DEFAULT_OUTPUT_DIR
+        return input_path.parent / default_dir_name
 
 
 def validate_input_file(filepath):
@@ -737,7 +756,7 @@ def get_image_info(filepath):
     }
 
 
-def resize_image(input_path, output_dir, sizes, dimension='width', quality=DEFAULT_RESIZE_QUALITY):
+def resize_image(input_path, output_dir, sizes, dimension='width', quality=DEFAULT_RESIZE_QUALITY, preserve_filename=False):
     """
     Resize an image to multiple sizes.
 
@@ -797,7 +816,10 @@ def resize_image(input_path, output_dir, sizes, dimension='width', quality=DEFAU
             resized_img = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
 
             # Prepare output filename
-            output_filename = f"{base_name}_{size}{extension}"
+            if preserve_filename:
+                output_filename = f"{base_name}{extension}"
+            else:
+                output_filename = f"{base_name}_{size}{extension}"
             output_path = output_dir / output_filename
 
             # Refuse to write through a symlink output path
@@ -1102,7 +1124,8 @@ def cmd_resize(args):
         sys.exit(EXIT_READ_ERROR)
 
     # Resolve output directory
-    output_dir = resolve_output_dir(args.output, input_path)
+    dir_name = get_resize_dir_name(sizes, dimension)
+    output_dir = resolve_output_dir(args.output, input_path, dir_name)
 
     # Print processing info
     print(f"Processing: {input_path.name} ({orig_width}x{orig_height})")
@@ -1116,7 +1139,8 @@ def cmd_resize(args):
             output_dir,
             sizes,
             dimension=dimension,
-            quality=args.quality
+            quality=args.quality,
+            preserve_filename=(len(sizes) == 1),
         )
     except OSError as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -1192,12 +1216,8 @@ def cmd_rename(args):
     )
 
     # Determine output directory
-    if args.output:
-        output_dir = Path(args.output)
-        # Create directory if it doesn't exist
-        output_dir.mkdir(parents=True, exist_ok=True)
-    else:
-        output_dir = input_path.parent
+    output_dir = resolve_output_dir(args.output, input_path, "renamed")
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     # Build output path
     output_path = output_dir / new_filename
@@ -1287,7 +1307,7 @@ def cmd_convert(args):
         pass
 
     # Determine output path
-    output_dir = resolve_output_dir(args.output, input_path)
+    output_dir = resolve_output_dir(args.output, input_path, "converted")
     target_ext = get_target_extension(args.format)
     output_filename = input_path.stem + target_ext
     output_path = output_dir / output_filename
@@ -1321,7 +1341,7 @@ def cmd_extract(args):
     input_path = validate_input_file(args.file)
 
     # Resolve output directory
-    output_dir = resolve_output_dir(args.output, input_path)
+    output_dir = resolve_output_dir(args.output, input_path, "extracted")
 
     # Check frame count
     try:
@@ -1426,7 +1446,7 @@ def _add_resize_parser(subparsers):
                                help='Comma-separated list of target heights (e.g., 400,800)')
     resize_parser.add_argument('file', help='Path to input image file')
     resize_parser.add_argument('--output', default=None,
-                               help='Output directory (default: output/ next to source file)')
+                               help='Output directory (default: resized-{size}{w|h}/ or resized/)')
     resize_parser.add_argument('--quality', type=int, default=DEFAULT_RESIZE_QUALITY,
                                help=f'JPEG quality 1-100 (default: {DEFAULT_RESIZE_QUALITY})')
     resize_parser.set_defaults(func=cmd_resize)
@@ -1444,7 +1464,7 @@ def _add_rename_parser(subparsers):
                                help='Correct file extension based on actual image format')
     rename_parser.add_argument('--prefix-exif-date', action='store_true',
                                help='Prepend EXIF date to filename (format: YYYY-MM-DDTHHMMSS_)')
-    rename_parser.add_argument('--output', help='Output directory (default: same as source file)')
+    rename_parser.add_argument('--output', help='Output directory (default: renamed/)')
     rename_parser.set_defaults(func=cmd_rename)
 
 
@@ -1459,7 +1479,7 @@ def _add_convert_parser(subparsers):
     convert_parser.add_argument('--format', '-f', required=True,
                                 help='Target format (jpeg, jpg, png, webp)')
     convert_parser.add_argument('--output', default=None,
-                                help='Output directory (default: output/ next to source file)')
+                                help='Output directory (default: converted/)')
     convert_parser.add_argument('--quality', type=int, default=DEFAULT_CONVERT_QUALITY,
                                 help=f'JPEG quality 1-100 (default: {DEFAULT_CONVERT_QUALITY})')
     convert_parser.add_argument('--strip-exif', action='store_true',
@@ -1477,7 +1497,7 @@ def _add_extract_parser(subparsers):
     )
     extract_parser.add_argument('file', help='Path to image file')
     extract_parser.add_argument('--output', default=None,
-                                help='Output directory (default: output/ next to source file)')
+                                help='Output directory (default: extracted/)')
     extract_parser.set_defaults(func=cmd_extract)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,29 @@ requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "ipro"
-version = "1.5.0"
+name = "ipro-cli"
+version = "1.5.1"
 description = "CLI tool for responsive image processing"
-requires-python = ">=3.8"
+readme = "PYPI_README.md"
 license = "MIT"
+requires-python = ">=3.8"
+authors = [
+    {name = "Neil Stoker"},
+]
+keywords = ["image", "resize", "convert", "webp", "heic", "cli", "responsive", "batch"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Multimedia :: Graphics :: Graphics Conversion",
+    "Topic :: Utilities",
+]
 dependencies = [
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0",
@@ -15,6 +33,11 @@ dependencies = [
 
 [project.scripts]
 ipro = "ipro:main"
+
+[project.urls]
+Homepage = "https://github.com/cadentdev/ipro"
+Repository = "https://github.com/cadentdev/ipro"
+Issues = "https://github.com/cadentdev/ipro/issues"
 
 [tool.setuptools]
 py-modules = ["ipro"]

--- a/tests/test_chain_cli.py
+++ b/tests/test_chain_cli.py
@@ -41,7 +41,7 @@ class TestChainResizeConvert:
         # Convert should have created one WebP file
         converted_files = list(output_convert.glob('*.webp'))
         assert len(converted_files) == 1
-        assert converted_files[0].stem == 'landscape_300'
+        assert converted_files[0].stem == 'landscape'
 
     def test_resize_multiple_then_convert(self, sample_landscape_image, temp_dir):
         """resize with multiple widths + convert: converts each resized file."""

--- a/tests/test_cli_direct.py
+++ b/tests/test_cli_direct.py
@@ -294,9 +294,9 @@ class TestCmdResizeDirect:
         cmd_resize(args)
 
         captured = capsys.readouterr()
-        assert 'test_300.jpg' in captured.out
+        assert 'test.jpg' in captured.out
         assert 'Successfully created 1 image' in captured.out
-        assert (output_dir / 'test_300.jpg').exists()
+        assert (output_dir / 'test.jpg').exists()
 
     def test_cmd_resize_multiple_widths(self, temp_dir, capsys):
         """Test cmd_resize with multiple widths."""
@@ -338,7 +338,7 @@ class TestCmdResizeDirect:
         cmd_resize(args)
 
         captured = capsys.readouterr()
-        assert 'test_400.jpg' in captured.out
+        assert 'test.jpg' in captured.out
         assert '600x400' in captured.out
 
     def test_cmd_resize_file_not_found(self, temp_dir):
@@ -636,7 +636,7 @@ class TestMainFunction:
         main()
 
         captured = capsys.readouterr()
-        assert 'test_300.jpg' in captured.out
+        assert 'test.jpg' in captured.out
 
     def test_main_resize_help(self, monkeypatch, capsys):
         """Test main with resize --help."""

--- a/tests/test_convert_cli.py
+++ b/tests/test_convert_cli.py
@@ -186,7 +186,7 @@ class TestConvertOutputDirectory:
 
             assert result.returncode == 0
             # Output should be next to source file, not in cwd
-            expected = src_dir / "output" / "test.png"
+            expected = src_dir / "converted" / "test.png"
             assert expected.exists()
 
     def test_custom_output_directory(self, sample_square_image, temp_dir):

--- a/tests/test_rename_cli.py
+++ b/tests/test_rename_cli.py
@@ -93,8 +93,8 @@ class TestRenameExtFlag:
         exit_code, stdout, stderr = run_ipro_rename(fake_heic, '--ext')
 
         assert exit_code == 0
-        # Check that new file was created with .jpg extension
-        expected_output = temp_dir / "photo.jpg"
+        # Check that new file was created with .jpg extension in renamed/ subdir
+        expected_output = temp_dir / "renamed" / "photo.jpg"
         assert expected_output.exists()
         # Original should still exist (non-destructive)
         assert fake_heic.exists()
@@ -111,9 +111,9 @@ class TestRenameExtFlag:
         assert exit_code == 0
         # On case-insensitive filesystems (macOS, Windows), photo.jpg and photo.JPG
         # are the same file. The command should succeed either way.
-        expected_output = temp_dir / "photo.jpg"
+        expected_output = temp_dir / "renamed" / "photo.jpg"
         # Check that a file with the correct name exists (case-insensitive check)
-        matching_files = list(temp_dir.glob("photo.[jJ][pP][gG]"))
+        matching_files = list((temp_dir / "renamed").glob("photo.[jJ][pP][gG]"))
         assert len(matching_files) >= 1
 
     def test_ext_creates_copy_not_moves(self, temp_dir):
@@ -126,8 +126,8 @@ class TestRenameExtFlag:
 
         # Original should still exist
         assert original.exists()
-        # New file should also exist
-        assert (temp_dir / "photo.jpg").exists()
+        # New file should also exist in renamed/ subdir
+        assert (temp_dir / "renamed" / "photo.jpg").exists()
 
     def test_ext_png_keeps_png_extension(self, sample_png_image):
         """Test that PNG file gets .png extension."""
@@ -136,7 +136,7 @@ class TestRenameExtFlag:
         assert exit_code == 0
         # File already has correct extension, should report no change needed
         # or the file should exist
-        expected_output = sample_png_image.parent / "test.png"
+        expected_output = sample_png_image.parent / "renamed" / "test.png"
         assert expected_output.exists()
         # Output should indicate no change or success
         combined = stdout + stderr
@@ -165,10 +165,10 @@ class TestRenamePrefixExifDate:
         )
 
         assert exit_code == 0
-        # Check that new file was created with date prefix
+        # Check that new file was created with date prefix in renamed/ subdir
         parent_dir = sample_image_with_exif.parent
         # The fixture uses EXIF_DATA_FULL which has date "2024:11:12 14:30:00"
-        expected_output = parent_dir / "2024-11-12T143000_with_exif.jpg"
+        expected_output = parent_dir / "renamed" / "2024-11-12T143000_with_exif.jpg"
         assert expected_output.exists()
 
     def test_prefix_exif_date_no_colons_in_output(self, sample_image_with_exif):
@@ -178,10 +178,10 @@ class TestRenamePrefixExifDate:
         )
 
         assert exit_code == 0
-        parent_dir = sample_image_with_exif.parent
+        parent_dir = sample_image_with_exif.parent / "renamed"
         # Find the new file
         new_files = [f for f in parent_dir.iterdir()
-                     if f.name.startswith('2024-') and f.name != sample_image_with_exif.name]
+                     if f.name.startswith('2024-')]
         assert len(new_files) == 1
         # Filename should not contain colons
         assert ':' not in new_files[0].name
@@ -235,7 +235,7 @@ class TestRenameCombinedFlags:
         assert exit_code == 0
         # Should have date prefix AND corrected extension
         # EXIF_DATA_FULL has date "2024:11:12 14:30:00"
-        expected = temp_dir / "2024-11-12T143000_photo.jpg"
+        expected = temp_dir / "renamed" / "2024-11-12T143000_photo.jpg"
         assert expected.exists()
 
     def test_combined_flags_order_independent(self, temp_dir):
@@ -255,7 +255,7 @@ class TestRenameCombinedFlags:
         )
 
         assert exit_code == 0
-        expected = temp_dir / "2024-11-12T143000_test.jpg"
+        expected = temp_dir / "renamed" / "2024-11-12T143000_test.jpg"
         assert expected.exists()
 
 
@@ -346,7 +346,7 @@ class TestRenameEdgeCases:
         exit_code, stdout, stderr = run_ipro_rename(original, '--ext')
 
         assert exit_code == 0
-        expected = temp_dir / "my photo.jpg"
+        expected = temp_dir / "renamed" / "my photo.jpg"
         assert expected.exists()
 
     def test_filename_with_multiple_dots(self, temp_dir):
@@ -358,7 +358,7 @@ class TestRenameEdgeCases:
         exit_code, stdout, stderr = run_ipro_rename(original, '--ext')
 
         assert exit_code == 0
-        expected = temp_dir / "photo.backup.jpg"
+        expected = temp_dir / "renamed" / "photo.backup.jpg"
         assert expected.exists()
 
     def test_output_file_already_exists(self, temp_dir):
@@ -367,8 +367,10 @@ class TestRenameEdgeCases:
         original = temp_dir / "photo.HEIC"
         img.save(original, 'JPEG')
 
-        # Create existing output file
-        existing = temp_dir / "photo.jpg"
+        # Create existing output file in renamed/ subdir
+        renamed_dir = temp_dir / "renamed"
+        renamed_dir.mkdir()
+        existing = renamed_dir / "photo.jpg"
         existing.write_text("existing content")
 
         exit_code, stdout, stderr = run_ipro_rename(original, '--ext')
@@ -390,5 +392,5 @@ class TestRenameEdgeCases:
         exit_code, stdout, stderr = run_ipro_rename(original, '--ext')
 
         assert exit_code == 0
-        expected = temp_dir / "фото.jpg"
+        expected = temp_dir / "renamed" / "фото.jpg"
         assert expected.exists()

--- a/tests/test_resize_cli.py
+++ b/tests/test_resize_cli.py
@@ -97,12 +97,12 @@ class TestResizeByWidth:
         )
 
         assert exit_code == 0
-        assert 'test_300.jpg' in stdout
+        assert 'test.jpg' in stdout
         assert '300x200' in stdout
         assert 'Successfully created 1 image' in stdout
 
         # Verify file was created
-        output_file = output_dir / 'test_300.jpg'
+        output_file = output_dir / 'test.jpg'
         assert output_file.exists()
 
         # Verify dimensions
@@ -147,11 +147,11 @@ class TestResizeByHeight:
         )
 
         assert exit_code == 0
-        assert 'test_400.jpg' in stdout
+        assert 'test.jpg' in stdout
         assert '600x400' in stdout  # Maintains aspect ratio
 
         # Verify file and dimensions
-        output_file = output_dir / 'test_400.jpg'
+        output_file = output_dir / 'test.jpg'
         assert output_file.exists()
 
         with Image.open(output_file) as img:
@@ -321,8 +321,8 @@ class TestResizeOutputHandling:
             assert result.returncode == 0
             assert 'Output directory:' in result.stdout
 
-            # Verify file was created in output/ next to source, not in cwd
-            assert (src_dir / 'output' / 'test_300.jpg').exists()
+            # Verify file was created in resized-300w/ next to source, not in cwd
+            assert (src_dir / 'resized-300w' / 'test.jpg').exists()
         finally:
             os.chdir(old_cwd)
 
@@ -341,7 +341,7 @@ class TestResizeOutputHandling:
         assert str(output_dir) in stdout
 
         # Verify file was created in custom directory
-        assert (output_dir / 'test_300.jpg').exists()
+        assert (output_dir / 'test.jpg').exists()
 
     def test_resize_creates_output_directory(self, temp_dir):
         """Test that output directory is created if it doesn't exist."""
@@ -358,7 +358,7 @@ class TestResizeOutputHandling:
 
         assert exit_code == 0
         assert output_dir.exists()
-        assert (output_dir / 'test_300.jpg').exists()
+        assert (output_dir / 'test.jpg').exists()
 
 
 class TestResizeExitCodes:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -143,7 +143,7 @@ class TestSymlinkProtection:
         symlink_dir.symlink_to(real_dir)
 
         with pytest.raises(SystemExit) as exc_info:
-            resolve_output_dir(str(symlink_dir), sample_square_image)
+            resolve_output_dir(str(symlink_dir), sample_square_image, "converted")
         assert exc_info.value.code == EXIT_INVALID_ARGS
 
     def test_validate_input_file_warns_on_symlink(self, temp_dir, capsys):


### PR DESCRIPTION
## Summary

- Replace generic `output/` with subcommand-named directories: `converted/`, `resized-1080w/`, `renamed/`, `extracted/`
- Single-width resize preserves original filename (size in dir name instead of file suffix)
- Chained commands produce flat sibling dirs instead of nesting (`output/output/`)
- Add `PYPI_README.md` and full PyPI package metadata (classifiers, keywords, URLs, author)
- Bump version to 1.6.0

Closes #21

## Output behavior

| Command | Default Output |
|---------|---------------|
| `ipro convert photo.heic -f jpeg` | `converted/photo.jpg` |
| `ipro resize photo.jpg -w 1080` | `resized-1080w/photo.jpg` |
| `ipro resize photo.jpg -h 800` | `resized-800h/photo.jpg` |
| `ipro resize photo.jpg -w 300,600` | `resized/photo_300.jpg`, `photo_600.jpg` |
| `ipro rename photo.HEIC --ext` | `renamed/photo.jpg` |
| `ipro extract multi.mpo` | `extracted/multi_001.jpg` |
| `resize -w 1080 + convert -f webp` | `resized-1080w/` + `converted/` (flat siblings) |

`--output ./foo` overrides all smart naming.

## Test plan

- [x] All 375 tests pass
- [x] Smoke test: single-width resize → `resized-1080w/photo.jpg`
- [x] Smoke test: multi-width resize → `resized/photo_300.jpg`
- [x] Smoke test: convert → `converted/photo.webp`
- [x] Smoke test: chain (resize + convert) → flat sibling dirs
- [x] `--output` override works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)